### PR TITLE
Fix live server build by adding envio codegen to build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "clean": "tsc --clean",
-    "build": "tsc --build",
+    "build": "envio codegen && tsc --build",
     "watch": "tsc --watch",
     "test": "node --import tsx/esm node_modules/mocha/bin/mocha.js test/**/*.ts",
     "codegen": "envio codegen",


### PR DESCRIPTION
Live server environment build phase requires running `envio codegen` before `tsc --build`. The build script in `package.json` was updated to `envio codegen && tsc --build` to fix the `MODULE_NOT_FOUND` error upon starting on the live environment.

---
*PR created automatically by Jules for task [18423438000122494850](https://jules.google.com/task/18423438000122494850) started by @Brad-is-Love*